### PR TITLE
Fix markdown syntax errors

### DIFF
--- a/dynamic-linking.ro.md
+++ b/dynamic-linking.ro.md
@@ -1,7 +1,7 @@
 # Linkare dinamică
 
 Linkarea dinamică înseamnă că în executabil nu sunt incluse componentele folosite din bibliotecă.
-Acestea vor fi incluse mai târziu, la încărcare (*load time*) sau chiar la rulare (*runtime).
+Acestea vor fi incluse mai târziu, la încărcare (*load time*) sau chiar la rulare (*runtime*).
 În urma linkării dinamice, executabilul reține referințe la bibliotecile folosite și la simbolurile folosite din cadrul acestora.
 Aceste referințe sunt similare unor simboluri nedefinite.
 Rezolvarea acestor simboluri are loc mai târziu, prin folosirea unui loader / linker dinamic.
@@ -13,7 +13,7 @@ Diferența este că acum, folosim linkare dinamică în loc de linkare statică 
 Pentru aceasta, am renunțat la argumentul `-static` folosit la linkare.
 
 Pentru acest exemplu, obținem un singur executabil `main`, din legarea statică cu biblioteca `libinc.a` și legarea dinamică cu biblioteca standard C.
-Similar exemplului din directorul `05-static/, folosim comanda `make` pentru a obține executabilul `main`:
+Similar exemplului din directorul `05-static/`, folosim comanda `make` pentru a obține executabilul `main`:
 
 ```console
 [..]/06-dynamic$ ls
@@ -39,11 +39,11 @@ main: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically link
 
 [..]/06-dynamic$ file ../05-static/main
 ../05-static/main: ELF 32-bit LSB executable, Intel 80386, version 1 (GNU/Linux), statically linked, for GNU/Linux 3.2.0, BuildID[sha1]=60adf8390374c898998c0b713a8b1ea0c255af38, not stripped
-``
+```
 
 Fișierul executabil `main` obținut prin linkare dinamică are un comportament identic fișierului executabil `main` obținut prin linkare statică.
 Observăm că dimensiunea sa este mult mai redusă: ocupă `7 KB` comparativ cu `600 KB` cât avea varianta sa statică.
-De asemenea, folosind utilitarul `file`, aflăm că este executabil obținut prin linkare dinamică (*dynamically linked*), în vreme cel obținut în exemplul anterior este executabil obținut prin linkare statică (*statically linked).
+De asemenea, folosind utilitarul `file`, aflăm că este executabil obținut prin linkare dinamică (*dynamically linked*), în vreme cel obținut în exemplul anterior este executabil obținut prin linkare statică (*statically linked*).
 
 Investigăm simbolurile executabilului:
 
@@ -66,7 +66,7 @@ Investigăm simbolurile executabilului:
 
 Simbolurile obținute din modulul obiect `main.o` și din biblioteca statică `libinc.o` sunt rezolvate și au adrese stabilite.
 Observăm că folosirea bibliotecii standard C a dus la existența simboblului `_start`, care este entry pointul programului.
-Dar, simbolurile din biblioteca standard C, (`printf`, __libc_start_main`) sunt marcate ca nedefinite (`U`).
+Dar, simbolurile din biblioteca standard C, (`printf, __libc_start_main`) sunt marcate ca nedefinite (`U`).
 Aceste simboluri nu sunt prezente în executabil: rezolvarea, stabilirea adreselor și relocarea lor se va realiza mai târziu, la încărcare (load time).
 
 La încărcare, o altă componentă software a sistemului, loaderul / linkerul dinamic, se va ocupa de:
@@ -77,11 +77,11 @@ La încărcare, o altă componentă software a sistemului, loaderul / linkerul d
 
 Putem investiga bibliotecile dinamice folosite de un executabil prin intermediul utilitarului `ldd`:
 
-``console
+```console
 [..]/06-dynamic$ ldd main
-	linux-gate.so.1 (0xf7f97000)
-	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d8a000)
-	/lib/ld-linux.so.2 (0xf7f98000)
+ linux-gate.so.1 (0xf7f97000)
+ libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d8a000)
+ /lib/ld-linux.so.2 (0xf7f98000)
 ```
 
 În rezultatul de mai sus, observăm că executabilul folosește biblioteca standard C, localizată la calea `/lib/i386-linux-gnu/libc.so.6`.
@@ -159,10 +159,10 @@ O eroare similară obținem dacă folosim utilitarul `ldd`:
 
 ```console
 [..]/07-dynlib$ ldd ./main
-	linux-gate.so.1 (0xf7f9f000)
-	libinc.so => not found
-	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d92000)
-	/lib/ld-linux.so.2 (0xf7fa0000)
+ linux-gate.so.1 (0xf7f9f000)
+ libinc.so => not found
+ libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d92000)
+ /lib/ld-linux.so.2 (0xf7fa0000)
 ```
 
 La fel, biblioteca `libinc.so` nu este găsită.
@@ -175,10 +175,10 @@ Odată folosită variabila de mediu `LD_LIBRARY_PATH`, lansarea în execuție a 
 
 ```console
 [..]/07-dynlib$ LD_LIBRARY_PATH=. ldd ./main
-	linux-gate.so.1 (0xf7eda000)
-	libinc.so => ./libinc.so (0xf7ed2000)
-	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7cca000)
-	/lib/ld-linux.so.2 (0xf7edb000)
+ linux-gate.so.1 (0xf7eda000)
+ libinc.so => ./libinc.so (0xf7ed2000)
+ libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7cca000)
+ /lib/ld-linux.so.2 (0xf7edb000)
 
 [..]/07-dynlib$ LD_LIBRARY_PATH=. ./main
 num_items: 1
@@ -186,4 +186,4 @@ num_items: 1
 
 Variabila de mediu `LD_LIBRARY_PATH` pentru loader este echivalentul opțiunii `-L` în comanda de linkare: precizează directoarele în care să fie căutate biblioteci pentru a fi încărcate, respectiv linkate.
 Folosirea variabilei de mediu `LD_LIBRARY_PATH` este recomandată pentru teste.
-Pentru o folosire robustă, există alte mijloace de precizare a căilor de căutare a bibliotecilor partajate, documentate în (pagina de manual a loaderului / linkerului dinamic)(https://man7.org/linux/man-pages/man8/ld.so.8.html#DESCRIPTION).
+Pentru o folosire robustă, există alte mijloace de precizare a căilor de căutare a bibliotecilor partajate, documentate în [pagina de manual a loaderului / linkerului dinamic](<https://man7.org/linux/man-pages/man8/ld.so.8.html#DESCRIPTION>).


### PR DESCRIPTION
Fixes multiple code block rendering errors where the tick ends weren't added appropriately.
Also fixes the hyperlink rendering at the end.