### PR TITLE
include stdlib.h

### DIFF
--- a/gnumake/custom/greeting.c
+++ b/gnumake/custom/greeting.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(void) {
 	printf("What's your name?\n");


### PR DESCRIPTION
```
cc custom/greeting.c -o greeting
custom/greeting.c: In function ‘main’:
custom/greeting.c:5:22: error: implicit declaration of function ‘calloc’ [-Wimplicit-function-declaration]
    5 |         char *name = calloc(101, sizeof(char));
      |                      ^~~~~~
custom/greeting.c:2:1: note: include ‘<stdlib.h>’ or provide a declaration of ‘calloc’
    1 | #include <stdio.h>
  +++ |+#include <stdlib.h>
    2 |
custom/greeting.c:5:22: warning: incompatible implicit declaration of built-in function ‘calloc’ [-Wbuiltin-declaration-mismatch]
    5 |         char *name = calloc(101, sizeof(char));
      |                      ^~~~~~
custom/greeting.c:5:22: note: include ‘<stdlib.h>’ or provide a declaration of ‘calloc’
custom/greeting.c:14:9: error: implicit declaration of function ‘free’ [-Wimplicit-function-declaration]
   14 |         free(name);
      |         ^~~~
custom/greeting.c:14:9: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
custom/greeting.c:14:9: warning: incompatible implicit declaration of built-in function ‘free’ [-Wbuiltin-declaration-mismatch]
custom/greeting.c:14:9: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
make: *** [Makefile:11: greeting] Error 1
```