### PR TITLE
fix markdown file

### DIFF
--- a/dynamic-linking.ro.md
+++ b/dynamic-linking.ro.md
@@ -1,7 +1,7 @@
 # Linkare dinamică
 
 Linkarea dinamică înseamnă că în executabil nu sunt incluse componentele folosite din bibliotecă.
-Acestea vor fi incluse mai târziu, la încărcare (*load time*) sau chiar la rulare (*runtime).
+Acestea vor fi incluse mai târziu, la încărcare (*load time*) sau chiar la rulare (*runtime*).
 În urma linkării dinamice, executabilul reține referințe la bibliotecile folosite și la simbolurile folosite din cadrul acestora.
 Aceste referințe sunt similare unor simboluri nedefinite.
 Rezolvarea acestor simboluri are loc mai târziu, prin folosirea unui loader / linker dinamic.
@@ -13,7 +13,7 @@ Diferența este că acum, folosim linkare dinamică în loc de linkare statică 
 Pentru aceasta, am renunțat la argumentul `-static` folosit la linkare.
 
 Pentru acest exemplu, obținem un singur executabil `main`, din legarea statică cu biblioteca `libinc.a` și legarea dinamică cu biblioteca standard C.
-Similar exemplului din directorul `05-static/, folosim comanda `make` pentru a obține executabilul `main`:
+Similar exemplului din directorul `05-static/`, folosim comanda `make` pentru a obține executabilul `main`:
 
 ```console
 [..]/06-dynamic$ ls
@@ -39,11 +39,11 @@ main: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically link
 
 [..]/06-dynamic$ file ../05-static/main
 ../05-static/main: ELF 32-bit LSB executable, Intel 80386, version 1 (GNU/Linux), statically linked, for GNU/Linux 3.2.0, BuildID[sha1]=60adf8390374c898998c0b713a8b1ea0c255af38, not stripped
-``
+```
 
 Fișierul executabil `main` obținut prin linkare dinamică are un comportament identic fișierului executabil `main` obținut prin linkare statică.
 Observăm că dimensiunea sa este mult mai redusă: ocupă `7 KB` comparativ cu `600 KB` cât avea varianta sa statică.
-De asemenea, folosind utilitarul `file`, aflăm că este executabil obținut prin linkare dinamică (*dynamically linked*), în vreme cel obținut în exemplul anterior este executabil obținut prin linkare statică (*statically linked).
+De asemenea, folosind utilitarul `file`, aflăm că este executabil obținut prin linkare dinamică (*dynamically linked*), în vreme ce cel obținut în exemplul anterior este executabil obținut prin linkare statică (*statically linked*).
 
 Investigăm simbolurile executabilului:
 
@@ -64,31 +64,31 @@ Investigăm simbolurile executabilului:
 [...]
 ```
 
-Simbolurile obținute din modulul obiect `main.o` și din biblioteca statică `libinc.o` sunt rezolvate și au adrese stabilite.
-Observăm că folosirea bibliotecii standard C a dus la existența simboblului `_start`, care este entry pointul programului.
-Dar, simbolurile din biblioteca standard C, (`printf`, __libc_start_main`) sunt marcate ca nedefinite (`U`).
-Aceste simboluri nu sunt prezente în executabil: rezolvarea, stabilirea adreselor și relocarea lor se va realiza mai târziu, la încărcare (load time).
+Simbolurile obținute din modulul obiect `main.o` și din biblioteca statică `libinc.a` sunt rezolvate și au adrese stabilite.
+Observăm că folosirea bibliotecii standard C a dus la existența simbolului `_start`, care este entry point-ul programului.
+Dar simbolurile din biblioteca standard C (`printf`, `__libc_start_main`) sunt marcate ca nedefinite (`U`).
+Aceste simboluri nu sunt prezente în executabil: rezolvarea, stabilirea adreselor și relocarea lor se va realiza mai târziu, la încărcare (*load time*).
 
 La încărcare, o altă componentă software a sistemului, loaderul / linkerul dinamic, se va ocupa de:
 
-- localizarea în sistemul de fișiere a fișierelor bibliotecă dinamice care sunt folosite de fișierul executabil încărcat
-- încărcarea în memorie a acelor biblioteci dinamice, lucru care duce și la stabilirea adreselor simbolurilor din bibliotecă
-- parcurgerea simbolurilor nedefinite din cadrul fișierului executabil, localizarea lor în biblioteca înacarcată dinamic și relocarea lor în executabilul încărcat în memorie
+* localizarea în sistemul de fișiere a fișierelor bibliotecă dinamice care sunt folosite de fișierul executabil încărcat
+* încărcarea în memorie a acelor biblioteci dinamice, lucru care duce și la stabilirea adreselor simbolurilor din bibliotecă
+* parcurgerea simbolurilor nedefinite din cadrul fișierului executabil, localizarea lor în biblioteca încărcată dinamic și relocarea lor în executabilul încărcat în memorie
 
 Putem investiga bibliotecile dinamice folosite de un executabil prin intermediul utilitarului `ldd`:
 
-``console
+```console
 [..]/06-dynamic$ ldd main
-	linux-gate.so.1 (0xf7f97000)
-	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d8a000)
-	/lib/ld-linux.so.2 (0xf7f98000)
+    linux-gate.so.1 (0xf7f97000)
+    libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d8a000)
+    /lib/ld-linux.so.2 (0xf7f98000)
 ```
 
 În rezultatul de mai sus, observăm că executabilul folosește biblioteca standard C, localizată la calea `/lib/i386-linux-gnu/libc.so.6`.
 `/lib/ld-linux.so.2` este loaderul / linkerul dinamic.
 `linux-gate.so.1` e o componentă specifică Linux pe care nu vom insista.
 
-Pe lângă dimensiunea redusă a executabilelor, marele avantaj al folosirii linkării dinamice, este că se pot partaja secțiunile de cod (nu de date) ale bibliotecilor dinamice.
+Pe lângă dimensiunea redusă a executabilelor, marele avantaj al folosirii linkării dinamice este că se pot partaja secțiunile de cod (nu de date) ale bibliotecilor dinamice.
 Când un executabil dinamic este încărcat, se identifică bibliotecile dinamice de care acesta depinde.
 Dacă o bibliotecă dinamică deja există în memorie, se face referire direct la zona existentă, partajând astfel biblioteca dinamică.
 Acest lucru conduce la o reducere semnificativă a memoriei ocupate de aplicațiile sistemului.
@@ -100,15 +100,15 @@ De aici este, în Linux, extensia `.so` a fișierelor de tip bibliotecă partaja
 ## Biblioteci cu linkare dinamică
 
 Numele corect al unei biblioteci dinamice este bibliotecă cu linkare dinamică (*dynamically linked library*) sau bibliotecă partajată.
-În Windows, bibliotecile dinamice sunt numite *dynamic-link libraries* de unde și extensia `.dll`.
+În Windows, bibliotecile dinamice sunt numite *dynamic-link libraries*, de unde și extensia `.dll`.
 
-Din punctul de vedere al comenzii folosite, nu diferă linkarea unei biblioteci dinamice sau a unei biblioci statice.
+Din punctul de vedere al comenzii folosite, nu diferă linkarea unei biblioteci dinamice sau a unei biblioteci statice.
 Diferă executabilul obținut, care va avea nedefinite simbolurile folosite din bibliotecile dinamice.
 De asemenea, loaderul / linkerul dinamic trebuie să fie informat de locul bibliotecii dinamice.
 
 În directorul `07-dynlib/` avem un conținut similar directorului `06-dynamic/`.
-Diferența este că acum, folosim linkare dinamică în loc de linkare statică și pentru a include funcționalitatea `inc.c`, nu doar pentru biblioteca standard C.
-Pentru aceasta, construim fișierul bibliotecă partajată `libinc.so`, în locul fișierului bibliotecă statică `libibc.a`.
+Diferența este că acum folosim linkare dinamică și pentru a include funcționalitatea `inc.c`, nu doar pentru biblioteca standard C.
+Pentru aceasta, construim fișierul bibliotecă partajată `libinc.so`, în locul fișierului bibliotecă statică `libinc.a`.
 
 Similar exemplului din directorul `06-dynamic/`, folosim comanda `make` pentru a obține executabilul `main`:
 
@@ -142,7 +142,7 @@ inc.c  inc.h  inc.o  libinc.so  main  main.c  main.o  Makefile
 08048440 T _start
 ```
 
-Executabilul obținut are dimensiunea în jur de `7 KB` puțin mai mică decât a executabilului din exemplul anterior.
+Executabilul obținut are dimensiunea în jur de `7 KB`, puțin mai mică decât a executabilului din exemplul anterior.
 Diferența cea mai mare este că, acum, simbolurile din biblioteca `libinc.so` (`increment`, `init`, `print`, `read`) sunt nerezolvate.
 
 Dacă încercăm lansarea în execuție a executabilului, observăm că primim o eroare:
@@ -153,16 +153,16 @@ Dacă încercăm lansarea în execuție a executabilului, observăm că primim o
 ```
 
 Eroarea spune că nu poate localiza biblioteca `libinc.so` la încărcare (*loading*).
-Este deci, o eroare de loader.
+Este deci o eroare de loader.
 
 O eroare similară obținem dacă folosim utilitarul `ldd`:
 
 ```console
 [..]/07-dynlib$ ldd ./main
-	linux-gate.so.1 (0xf7f9f000)
-	libinc.so => not found
-	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d92000)
-	/lib/ld-linux.so.2 (0xf7fa0000)
+    linux-gate.so.1 (0xf7f9f000)
+    libinc.so => not found
+    libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d92000)
+    /lib/ld-linux.so.2 (0xf7fa0000)
 ```
 
 La fel, biblioteca `libinc.so` nu este găsită.
@@ -175,10 +175,10 @@ Odată folosită variabila de mediu `LD_LIBRARY_PATH`, lansarea în execuție a 
 
 ```console
 [..]/07-dynlib$ LD_LIBRARY_PATH=. ldd ./main
-	linux-gate.so.1 (0xf7eda000)
-	libinc.so => ./libinc.so (0xf7ed2000)
-	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7cca000)
-	/lib/ld-linux.so.2 (0xf7edb000)
+    linux-gate.so.1 (0xf7eda000)
+    libinc.so => ./libinc.so (0xf7ed2000)
+    libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7cca000)
+    /lib/ld-linux.so.2 (0xf7edb000)
 
 [..]/07-dynlib$ LD_LIBRARY_PATH=. ./main
 num_items: 1
@@ -186,4 +186,4 @@ num_items: 1
 
 Variabila de mediu `LD_LIBRARY_PATH` pentru loader este echivalentul opțiunii `-L` în comanda de linkare: precizează directoarele în care să fie căutate biblioteci pentru a fi încărcate, respectiv linkate.
 Folosirea variabilei de mediu `LD_LIBRARY_PATH` este recomandată pentru teste.
-Pentru o folosire robustă, există alte mijloace de precizare a căilor de căutare a bibliotecilor partajate, documentate în (pagina de manual a loaderului / linkerului dinamic)(https://man7.org/linux/man-pages/man8/ld.so.8.html#DESCRIPTION).
+Pentru o folosire robustă, există alte mijloace de precizare a căilor de căutare a bibliotecilor partajate, documentate în [pagina de manual a loaderului / linkerului dinamic](https://man7.org/linux/man-pages/man8/ld.so.8.html#DESCRIPTION).


### PR DESCRIPTION
Am corectat erorile de Markdown din fișierul dynamic-linking.ro.md:
- am corectat blocurile de cod închise greșit
- am corectat declarațiile de tip "```console"
- am corectat sintaxa linkurilor
- am corectat greșeli de tipar (ex: "simboblului", "biblioci", "inacarcată")