### PR TITLE
Fixed dynamic-linking.ro.md syntax

### DIFF
--- a/dynamic-linking.ro.md
+++ b/dynamic-linking.ro.md
@@ -1,7 +1,7 @@
 # Linkare dinamică
 
 Linkarea dinamică înseamnă că în executabil nu sunt incluse componentele folosite din bibliotecă.
-Acestea vor fi incluse mai târziu, la încărcare (*load time*) sau chiar la rulare (*runtime).
+Acestea vor fi incluse mai târziu, la încărcare (*load time*) sau chiar la rulare (*runtime*).
 În urma linkării dinamice, executabilul reține referințe la bibliotecile folosite și la simbolurile folosite din cadrul acestora.
 Aceste referințe sunt similare unor simboluri nedefinite.
 Rezolvarea acestor simboluri are loc mai târziu, prin folosirea unui loader / linker dinamic.
@@ -13,7 +13,7 @@ Diferența este că acum, folosim linkare dinamică în loc de linkare statică 
 Pentru aceasta, am renunțat la argumentul `-static` folosit la linkare.
 
 Pentru acest exemplu, obținem un singur executabil `main`, din legarea statică cu biblioteca `libinc.a` și legarea dinamică cu biblioteca standard C.
-Similar exemplului din directorul `05-static/, folosim comanda `make` pentru a obține executabilul `main`:
+Similar exemplului din directorul `05-static/`, folosim comanda `make` pentru a obține executabilul `main`:
 
 ```console
 [..]/06-dynamic$ ls
@@ -39,11 +39,11 @@ main: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically link
 
 [..]/06-dynamic$ file ../05-static/main
 ../05-static/main: ELF 32-bit LSB executable, Intel 80386, version 1 (GNU/Linux), statically linked, for GNU/Linux 3.2.0, BuildID[sha1]=60adf8390374c898998c0b713a8b1ea0c255af38, not stripped
-``
+```
 
 Fișierul executabil `main` obținut prin linkare dinamică are un comportament identic fișierului executabil `main` obținut prin linkare statică.
 Observăm că dimensiunea sa este mult mai redusă: ocupă `7 KB` comparativ cu `600 KB` cât avea varianta sa statică.
-De asemenea, folosind utilitarul `file`, aflăm că este executabil obținut prin linkare dinamică (*dynamically linked*), în vreme cel obținut în exemplul anterior este executabil obținut prin linkare statică (*statically linked).
+De asemenea, folosind utilitarul `file`, aflăm că este executabil obținut prin linkare dinamică (*dynamically linked*), în vreme cel obținut în exemplul anterior este executabil obținut prin linkare statică (*statically linked*).
 
 Investigăm simbolurile executabilului:
 
@@ -66,8 +66,8 @@ Investigăm simbolurile executabilului:
 
 Simbolurile obținute din modulul obiect `main.o` și din biblioteca statică `libinc.o` sunt rezolvate și au adrese stabilite.
 Observăm că folosirea bibliotecii standard C a dus la existența simboblului `_start`, care este entry pointul programului.
-Dar, simbolurile din biblioteca standard C, (`printf`, __libc_start_main`) sunt marcate ca nedefinite (`U`).
-Aceste simboluri nu sunt prezente în executabil: rezolvarea, stabilirea adreselor și relocarea lor se va realiza mai târziu, la încărcare (load time).
+Dar, simbolurile din biblioteca standard C, (`printf`, `__libc_start_main`) sunt marcate ca nedefinite (`U`).
+Aceste simboluri nu sunt prezente în executabil: rezolvarea, stabilirea adreselor și relocarea lor se va realiza mai târziu, la încărcare (*load time*).
 
 La încărcare, o altă componentă software a sistemului, loaderul / linkerul dinamic, se va ocupa de:
 
@@ -77,7 +77,7 @@ La încărcare, o altă componentă software a sistemului, loaderul / linkerul d
 
 Putem investiga bibliotecile dinamice folosite de un executabil prin intermediul utilitarului `ldd`:
 
-``console
+```console
 [..]/06-dynamic$ ldd main
 	linux-gate.so.1 (0xf7f97000)
 	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d8a000)
@@ -88,7 +88,7 @@ Putem investiga bibliotecile dinamice folosite de un executabil prin intermediul
 `/lib/ld-linux.so.2` este loaderul / linkerul dinamic.
 `linux-gate.so.1` e o componentă specifică Linux pe care nu vom insista.
 
-Pe lângă dimensiunea redusă a executabilelor, marele avantaj al folosirii linkării dinamice, este că se pot partaja secțiunile de cod (nu de date) ale bibliotecilor dinamice.
+Pe lângă dimensiunea redusă a executabilelor, marele avantaj al folosirii linkării dinamice, este că se pot partaja secțiunile de cod (*nu de date*) ale bibliotecilor dinamice.
 Când un executabil dinamic este încărcat, se identifică bibliotecile dinamice de care acesta depinde.
 Dacă o bibliotecă dinamică deja există în memorie, se face referire direct la zona existentă, partajând astfel biblioteca dinamică.
 Acest lucru conduce la o reducere semnificativă a memoriei ocupate de aplicațiile sistemului.
@@ -108,7 +108,7 @@ De asemenea, loaderul / linkerul dinamic trebuie să fie informat de locul bibli
 
 În directorul `07-dynlib/` avem un conținut similar directorului `06-dynamic/`.
 Diferența este că acum, folosim linkare dinamică în loc de linkare statică și pentru a include funcționalitatea `inc.c`, nu doar pentru biblioteca standard C.
-Pentru aceasta, construim fișierul bibliotecă partajată `libinc.so`, în locul fișierului bibliotecă statică `libibc.a`.
+Pentru aceasta, construim fișierul bibliotecă partajată `libinc.so`, în locul fișierului bibliotecă statică `libinc.a`.
 
 Similar exemplului din directorul `06-dynamic/`, folosim comanda `make` pentru a obține executabilul `main`:
 
@@ -142,7 +142,7 @@ inc.c  inc.h  inc.o  libinc.so  main  main.c  main.o  Makefile
 08048440 T _start
 ```
 
-Executabilul obținut are dimensiunea în jur de `7 KB` puțin mai mică decât a executabilului din exemplul anterior.
+Executabilul obținut are dimensiunea în jur de `7 KB`, puțin mai mică decât a executabilului din exemplul anterior.
 Diferența cea mai mare este că, acum, simbolurile din biblioteca `libinc.so` (`increment`, `init`, `print`, `read`) sunt nerezolvate.
 
 Dacă încercăm lansarea în execuție a executabilului, observăm că primim o eroare:
@@ -186,4 +186,4 @@ num_items: 1
 
 Variabila de mediu `LD_LIBRARY_PATH` pentru loader este echivalentul opțiunii `-L` în comanda de linkare: precizează directoarele în care să fie căutate biblioteci pentru a fi încărcate, respectiv linkate.
 Folosirea variabilei de mediu `LD_LIBRARY_PATH` este recomandată pentru teste.
-Pentru o folosire robustă, există alte mijloace de precizare a căilor de căutare a bibliotecilor partajate, documentate în (pagina de manual a loaderului / linkerului dinamic)(https://man7.org/linux/man-pages/man8/ld.so.8.html#DESCRIPTION).
+Pentru o folosire robustă, există alte mijloace de precizare a căilor de căutare a bibliotecilor partajate, documentate în [pagina de manual a loaderului / linkerului dinamic](https://man7.org/linux/man-pages/man8/ld.so.8.html#DESCRIPTION).

--- a/dynamic-linking.ro.md
+++ b/dynamic-linking.ro.md
@@ -43,7 +43,7 @@ main: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically link
 
 Fișierul executabil `main` obținut prin linkare dinamică are un comportament identic fișierului executabil `main` obținut prin linkare statică.
 Observăm că dimensiunea sa este mult mai redusă: ocupă `7 KB` comparativ cu `600 KB` cât avea varianta sa statică.
-De asemenea, folosind utilitarul `file`, aflăm că este executabil obținut prin linkare dinamică (*dynamically linked*), în vreme cel obținut în exemplul anterior este executabil obținut prin linkare statică (*statically linked*).
+De asemenea, folosind utilitarul `file`, aflăm că este executabil obținut prin linkare dinamică (*dynamically linked*), în vreme ce cel obținut în exemplul anterior este executabil obținut prin linkare statică (*statically linked*).
 
 Investigăm simbolurile executabilului:
 
@@ -65,7 +65,7 @@ Investigăm simbolurile executabilului:
 ```
 
 Simbolurile obținute din modulul obiect `main.o` și din biblioteca statică `libinc.o` sunt rezolvate și au adrese stabilite.
-Observăm că folosirea bibliotecii standard C a dus la existența simboblului `_start`, care este entry pointul programului.
+Observăm că folosirea bibliotecii standard C a dus la existența simbolului `_start`, care este entry pointul programului.
 Dar, simbolurile din biblioteca standard C, (`printf`, `__libc_start_main`) sunt marcate ca nedefinite (`U`).
 Aceste simboluri nu sunt prezente în executabil: rezolvarea, stabilirea adreselor și relocarea lor se va realiza mai târziu, la încărcare (*load time*).
 

--- a/helloworld.md
+++ b/helloworld.md
@@ -1,0 +1,203 @@
+# Helloworld Programs
+
+### Hello, World!
+
+We list bellow Helloworld programs for different programming languages, i.e. programs that print "Hello, World!". The specified compiler or interpreter is required for each programming languages.
+The table below summarizes the programs:
+
+| Language | Language (Spec) Site | Section | Build / Run Toolchain | Debian / Ubuntu Packages |
+| :--- | :--- | :--- | :--- | :--- |
+| C | [The Standard - C](https://www.iso-9899.info/wiki/The_Standard) | [C](#) | GCC | build-essential |
+| C++ | [The Standard - C++](https://isocpp.org/std/the-standard) | [C++](#) | GCC / G++ | build-essential, g++ |
+| Dlang | [D Programming Language: Home](dlang.org) | [Dlang](#) | GCC / GDC | build-essential, gdc |
+| Go | [The Go Programming Language](go.dev) | [Go](#) | Go | golang |
+| Rust | [Rust Programming Language](rust-lang.org) | [Rust](#) | Rust (Crate) | rustlang |
+| Java | [Java Programming Language](https://docs.oracle.com/javase/8/docs/technotes/guides/language/) | [Java](#) | JDK | openjdk-17-jdk |
+| x86 64 assembly | [x86 and amd64 instruction reference](https://www.felixcloutier.com/x86/) | [x86_64 Assembly](#) | GCC / GAS | build-essential |
+| ARM64 assembly | [Arm A64 Instruction Set Architecture](https://developer.arm.com/documentation/ddi0596/latest/) | [ARM64 Assembly](#) | GCC / GAS (AArch64) | build-essential |
+| Bash | [Bash Reference Manual](https://www.gnu.org/software/bash/manual/bash.html) | [Bash](#) | Bash | bash |
+| Python | [Welcome to Python.org](python.org) | [Python](#) | Python | python |
+| Ruby | [Ruby Programming Language](ruby-lang.org/en/) | [Ruby](#) | Ruby | ruby |
+| PHP | [PHP: Hypertext Preprocessor](php.net) | [PHP](#) | PHP | php |
+| Perl | [The Perl Programming Language](perl.org) | [Perl](#) | Perl | perl |
+| Lua | [The Programming Language Lua](lua.org) | [Lua](#) | Lua | lua |
+
+## C
+```c
+#include <stdio.h>
+
+int main(void)
+{
+    puts("Hello, World!");
+    return 0;
+}
+```
+
+Build with:
+```console
+gcc -Wall -o helloworld helloworld.c
+```
+
+Run with:
+```console
+./helloworld
+```
+
+## Dlang
+```dlang
+import std.stdio;
+
+void main()
+{
+    writeln("Hello, World!");
+}
+```
+
+Build with:
+```console
+gdc -Wall -o helloworld helloworld.cpp
+```
+
+Run with:
+```console
+./helloworld
+```
+
+## Go
+```go
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, World!")
+}
+```
+
+Build and run with:
+```console
+go run helloworld.go
+```
+
+## Rust
+```rust
+fn main() {
+    println!("Hello, World");
+}
+```
+
+Build with:
+```console
+rustc hello.rs
+```
+
+Run with:
+```console
+./helloworld
+```
+
+## Java
+```java
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}
+```
+
+Build with:
+```console
+javac HelloWorld.java
+```
+
+Run with:
+```console
+java HelloWorld
+```
+
+## x86_64 Assembly
+
+Build with:
+```console
+TODO
+```
+
+Run with:
+```console
+./helloworld
+```
+TODO
+
+## ARM64 Assembly
+
+Build with:
+```console
+TODO
+```
+
+Run with:
+```console
+./helloworld
+```
+
+## Bash
+```bash
+echo "Hello, World!"
+```
+
+Run with:
+```console
+bash helloworld.sh
+```
+
+## Python
+```python
+print("Hello, World!")
+```
+
+Run with:
+```console
+python helloworld.py
+```
+
+## Ruby
+```ruby
+puts "Hello, World!"
+```
+
+Run with:
+```console
+ruby helloworld.rb
+```
+
+## PHP
+```php
+<?php
+echo "Hello, World!"
+?>
+```
+
+Run with:
+```console
+./helloworld
+```
+
+## Perl
+```perl
+print("Hello, World!\n")
+```
+
+Run with:
+```console
+perl helloworld.pl
+```
+
+## Lua
+```lua
+print("Hello, World!")
+```
+
+Run with:
+```console
+lua helloworld.lua
+```


### PR DESCRIPTION
Fixed dynamic-linking.ro.md syntax.
Multiple Markdown errors on 10+ lines.